### PR TITLE
feat: explicitly close messages channel on exit notification

### DIFF
--- a/lspower-macros/src/lib.rs
+++ b/lspower-macros/src/lib.rs
@@ -222,6 +222,7 @@ fn gen_server_router(trait_name: &syn::Ident, methods: &[MethodCall]) -> proc_ma
         mod generated_impl {
             use super::{#trait_name};
             use crate::{
+                client::Client,
                 jsonrpc::{not_initialized_error, Error, ErrorCode, Id, Outgoing, Response, ServerRequests, Version},
                 server::{State, StateKind},
                 service::ExitedError,
@@ -297,6 +298,7 @@ fn gen_server_router(trait_name: &syn::Ident, methods: &[MethodCall]) -> proc_ma
                 state: &Arc<State>,
                 pending: &ServerRequests,
                 request: ServerRequest,
+                client: Client,
             ) -> Pin<Box<dyn Future<Output = Result<Option<Outgoing>, ExitedError>> + Send>> {
                 use Params::*;
 
@@ -325,6 +327,7 @@ fn gen_server_router(trait_name: &syn::Ident, methods: &[MethodCall]) -> proc_ma
                         info!("exit notification received, stopping");
                         state.set(StateKind::Exited);
                         pending.cancel_all();
+                        client.close();
                         future::ok(None).boxed()
                     }
                     (other, StateKind::Uninitialized) => Box::pin(match other.id().cloned() {

--- a/src/client.rs
+++ b/src/client.rs
@@ -135,6 +135,18 @@ impl Client {
         }
     }
 
+    /// Close the client.
+    /// Closing the client is not required but doing so will ensure that no more messages can be
+    /// produced. The receiver of the messages will be able to consume any in-flight messages and
+    /// then will observe the end of the stream.
+    ///
+    /// If the client is never closed and never dropped the reveiver of the messages will never observe the end of
+    /// the stream.
+    pub fn close(&self) {
+        let mut sender = self.inner.sender.clone();
+        sender.close_channel();
+    }
+
     /// Notifies the client to log a particular message.
     ///
     /// This corresponds to the [`window/logMessage`] notification.


### PR DESCRIPTION
With this change the client can be explicitly closed. This allows for
the receiver of the messages channel to observe the end of the stream
and terminate.