### PR TITLE
feat: explicitly close messages channel on exit notification

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -135,6 +135,18 @@ impl Client {
         }
     }
 
+    /// Close the client.
+    /// Closing the client is not required but doing so will ensure that no more messages can be
+    /// produced. The receiver of the messages will be able to consume any in-flight messages and
+    /// then will observe the end of the stream.
+    ///
+    /// If the client is never closed and never dropped the reveiver of the messages will never observe the end of
+    /// the stream.
+    pub fn close(&self) {
+        let mut sender = self.inner.sender.clone();
+        sender.close_channel();
+    }
+
     /// Notifies the client to log a particular message.
     ///
     /// This corresponds to the [`window/logMessage`] notification.


### PR DESCRIPTION
With this change the client can be explicitly closed. This allows for
the receiver of the messages channel to observe the end of the stream
and terminate.

For some context see this change for how it simplifies our usage of lspower. https://github.com/influxdata/flux-lsp/pull/357

TL;DR We use lspower to run a language server in the browser via WASM. As such we do not use the Server type but have an API exposed to Javascript that directly calls the Service.call method. As a result we need to manage the reading of messages to the client and therefore need to observe when the message channel is complete.

Replaces #20 